### PR TITLE
Fetch list of Bullrun ride requests from Nostr relay

### DIFF
--- a/apps/nostr-demo/App.tsx
+++ b/apps/nostr-demo/App.tsx
@@ -3,11 +3,12 @@ import { StatusBar } from 'expo-status-bar'
 import { useEffect } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { greeting } from '@arcadecity/ui'
-import { createNewAccount } from './nostr'
+import { createNewAccount, subscribeToRides } from './nostr'
 
 export default function App() {
   useEffect(() => {
     createNewAccount()
+    subscribeToRides()
   }, [])
   return (
     <View style={styles.container}>

--- a/apps/nostr-demo/App.tsx
+++ b/apps/nostr-demo/App.tsx
@@ -1,9 +1,14 @@
+import 'text-encoding-polyfill'
 import { StatusBar } from 'expo-status-bar'
+import { useEffect } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
-// @ts-ignore
 import { greeting } from '@arcadecity/ui'
+import { createNewAccount } from './nostr'
 
 export default function App() {
+  useEffect(() => {
+    createNewAccount()
+  }, [])
   return (
     <View style={styles.container}>
       <Text>{greeting}</Text>

--- a/apps/nostr-demo/dec.d.ts
+++ b/apps/nostr-demo/dec.d.ts
@@ -1,0 +1,1 @@
+declare module '@arcadecity/ui'

--- a/apps/nostr-demo/nostr-tools.ts
+++ b/apps/nostr-demo/nostr-tools.ts
@@ -1,0 +1,35 @@
+/**
+ * Doing our own version of https://github.com/fiatjaf/nostr-tools with native shims as necessary,
+ * updated libraries (e.g. @scure/bip39 instead of micro-bip39), and better TypeScript support.
+ * Otherwise will try to preserve the same API.
+ */
+
+import { HDKey } from '@scure/bip32'
+import {
+  generateMnemonic, mnemonicToSeedSync, validateMnemonic
+} from '@scure/bip39'
+import { wordlist } from '@scure/bip39/wordlists/english'
+
+/**
+ * NIP 06: Key derivation from mnemonic seed
+ * https://github.com/nostr-protocol/nips/blob/master/06.md
+ */
+
+export function privateKeyFromSeed(seed: string) {
+  let root = HDKey.fromMasterSeed(Buffer.from(seed, 'hex'))
+  const key = root.derive(`m/44'/1237'/0'/0/0`).privateKey
+  if (!key) throw new Error('Failed to derive private key')
+  return Buffer.from(key).toString('hex')
+}
+
+export function generateSeedWords() {
+  return generateMnemonic(wordlist)
+}
+
+export function seedFromWords(mnemonic: string) {
+  return Buffer.from(mnemonicToSeedSync(mnemonic)).toString('hex')
+}
+
+export function validateWords(words: string) {
+  return validateMnemonic(words, wordlist)
+}

--- a/apps/nostr-demo/nostr-tools/event.js
+++ b/apps/nostr-demo/nostr-tools/event.js
@@ -1,0 +1,49 @@
+import { Buffer } from 'buffer'
+import createHash from 'create-hash'
+import * as secp256k1 from '@noble/secp256k1'
+
+export function getBlankEvent() {
+  return {
+    kind: 255,
+    pubkey: null,
+    content: '',
+    tags: [],
+    created_at: 0,
+  }
+}
+
+export function serializeEvent(evt) {
+  return JSON.stringify([0, evt.pubkey, evt.created_at, evt.kind, evt.tags, evt.content])
+}
+
+export function getEventHash(event) {
+  let eventHash = createHash('sha256')
+    .update(Buffer.from(serializeEvent(event)))
+    .digest()
+  return Buffer.from(eventHash).toString('hex')
+}
+
+export function validateEvent(event) {
+  if (event.id !== getEventHash(event)) return false
+  if (typeof event.content !== 'string') return false
+  if (typeof event.created_at !== 'number') return false
+
+  if (!Array.isArray(event.tags)) return false
+  for (let i = 0; i < event.tags.length; i++) {
+    let tag = event.tags[i]
+    if (!Array.isArray(tag)) return false
+    for (let j = 0; j < tag.length; j++) {
+      if (typeof tag[j] === 'object') return false
+    }
+  }
+
+  return true
+}
+
+export function verifySignature(event) {
+  return secp256k1.schnorr.verify(event.sig, event.id, event.pubkey)
+}
+
+export async function signEvent(event, key) {
+  return Buffer.from(await secp256k1.schnorr.sign(getEventHash(event), key)).toString('hex')
+}

--- a/apps/nostr-demo/nostr-tools/filter.js
+++ b/apps/nostr-demo/nostr-tools/filter.js
@@ -1,0 +1,27 @@
+export function matchFilter(filter, event) {
+  if (filter.ids && filter.ids.indexOf(event.id) === -1) return false
+  if (filter.kinds && filter.kinds.indexOf(event.kind) === -1) return false
+  if (filter.authors && filter.authors.indexOf(event.pubkey) === -1) return false
+
+  for (let f in filter) {
+    if (f[0] === '#') {
+      if (
+        filter[f] &&
+        !event.tags.find(([t, v]) => t === f.slice(1) && filter[f].indexOf(v) !== -1)
+      )
+        return false
+    }
+  }
+
+  if (filter.since && event.created_at < filter.since) return false
+  if (filter.until && event.created_at >= filter.until) return false
+
+  return true
+}
+
+export function matchFilters(filters, event) {
+  for (let i = 0; i < filters.length; i++) {
+    if (matchFilter(filters[i], event)) return true
+  }
+  return false
+}

--- a/apps/nostr-demo/nostr-tools/index.ts
+++ b/apps/nostr-demo/nostr-tools/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Doing our own version of https://github.com/fiatjaf/nostr-tools with native shims as necessary,
+ * updated libraries (e.g. @scure/bip39 instead of micro-bip39), and better TypeScript support.
+ * Otherwise will try to preserve the same API.
+ */
+
+export * from './keys'
+export * from './nip06'
+export * from './pool'

--- a/apps/nostr-demo/nostr-tools/keys.ts
+++ b/apps/nostr-demo/nostr-tools/keys.ts
@@ -1,0 +1,5 @@
+import * as secp256k1 from '@noble/secp256k1'
+
+export function getPublicKey(privateKey: Buffer) {
+  return Buffer.from(secp256k1.schnorr.getPublicKey(privateKey)).toString('hex')
+}

--- a/apps/nostr-demo/nostr-tools/nip06.ts
+++ b/apps/nostr-demo/nostr-tools/nip06.ts
@@ -1,9 +1,3 @@
-/**
- * Doing our own version of https://github.com/fiatjaf/nostr-tools with native shims as necessary,
- * updated libraries (e.g. @scure/bip39 instead of micro-bip39), and better TypeScript support.
- * Otherwise will try to preserve the same API.
- */
-
 import { HDKey } from '@scure/bip32'
 import {
   generateMnemonic, mnemonicToSeedSync, validateMnemonic

--- a/apps/nostr-demo/nostr-tools/pool.js
+++ b/apps/nostr-demo/nostr-tools/pool.js
@@ -1,0 +1,196 @@
+import { getEventHash, verifySignature, signEvent } from './event.js'
+import { relayConnect, normalizeRelayURL } from './relay.js'
+
+export function relayPool() {
+  var globalPrivateKey
+  var globalSigningFunction
+
+  const poolPolicy = {
+    // setting this to a number will cause events to be published to a random
+    // set of relays only, instead of publishing to all relays all the time
+    randomChoice: null,
+
+    // setting this to true will cause .publish() calls to wait until the event has
+    // been published -- or at least attempted to be published -- to all relays
+    wait: false,
+  }
+  const relays = {}
+  const noticeCallbacks = []
+
+  function propagateNotice(notice, relayURL) {
+    for (let i = 0; i < noticeCallbacks.length; i++) {
+      let { relay } = relays[relayURL]
+      noticeCallbacks[i](notice, relay)
+    }
+  }
+
+  const activeSubscriptions = {}
+
+  const sub = ({ cb, filter, beforeSend }, id) => {
+    if (!id) id = Math.random().toString().slice(2)
+
+    const subControllers = Object.fromEntries(
+      Object.values(relays)
+        .filter(({ policy }) => policy.read)
+        .map(({ relay }) => [
+          relay.url,
+          relay.sub({ cb: (event) => cb(event, relay.url), filter, beforeSend }, id),
+        ])
+    )
+
+    const activeCallback = cb
+    const activeFilters = filter
+    const activeBeforeSend = beforeSend
+
+    const unsub = () => {
+      Object.values(subControllers).forEach((sub) => sub.unsub())
+      delete activeSubscriptions[id]
+    }
+    const sub = ({
+      cb = activeCallback,
+      filter = activeFilters,
+      beforeSend = activeBeforeSend,
+    }) => {
+      Object.entries(subControllers).map(([relayURL, sub]) => [
+        relayURL,
+        sub.sub({ cb: (event) => cb(event, relayURL), filter, beforeSend }, id),
+      ])
+      return activeSubscriptions[id]
+    }
+    const addRelay = (relay) => {
+      subControllers[relay.url] = relay.sub(
+        { cb: (event) => cb(event, relay.url), filter, beforeSend },
+        id
+      )
+      return activeSubscriptions[id]
+    }
+    const removeRelay = (relayURL) => {
+      if (relayURL in subControllers) {
+        subControllers[relayURL].unsub()
+        if (Object.keys(subControllers).length === 0) unsub()
+      }
+      return activeSubscriptions[id]
+    }
+
+    activeSubscriptions[id] = {
+      sub,
+      unsub,
+      addRelay,
+      removeRelay,
+    }
+
+    return activeSubscriptions[id]
+  }
+
+  return {
+    sub,
+    relays,
+    setPrivateKey(privateKey) {
+      globalPrivateKey = privateKey
+    },
+    registerSigningFunction(fn) {
+      globalSigningFunction = fn
+    },
+    setPolicy(key, value) {
+      poolPolicy[key] = value
+    },
+    addRelay(url, policy = { read: true, write: true }) {
+      let relayURL = normalizeRelayURL(url)
+      if (relayURL in relays) return
+
+      let relay = relayConnect(url, (notice) => {
+        propagateNotice(notice, relayURL)
+      })
+      relays[relayURL] = { relay, policy }
+
+      if (policy.read) {
+        Object.values(activeSubscriptions).forEach((subscription) => subscription.addRelay(relay))
+      }
+
+      return relay
+    },
+    removeRelay(url) {
+      let relayURL = normalizeRelayURL(url)
+      let data = relays[relayURL]
+      if (!data) return
+
+      let { relay } = data
+      Object.values(activeSubscriptions).forEach((subscription) => subscription.removeRelay(relay))
+      relay.close()
+      delete relays[relayURL]
+    },
+    onNotice(cb) {
+      noticeCallbacks.push(cb)
+    },
+    offNotice(cb) {
+      let index = noticeCallbacks.indexOf(cb)
+      if (index !== -1) noticeCallbacks.splice(index, 1)
+    },
+    async publish(event, statusCallback) {
+      event.id = getEventHash(event)
+
+      if (!event.sig) {
+        event.tags = event.tags || []
+
+        if (globalPrivateKey) {
+          event.sig = await signEvent(event, globalPrivateKey)
+        } else if (globalSigningFunction) {
+          event.sig = await globalSigningFunction(event)
+          if (!event.sig) {
+            // abort here
+            return
+          } else {
+            // check
+            if (!(await verifySignature(event)))
+              throw new Error('signature provided by custom signing function is invalid.')
+          }
+        } else {
+          throw new Error(
+            "can't publish unsigned event. either sign this event beforehand, provide a signing function or pass a private key while initializing this relay pool so it can be signed automatically."
+          )
+        }
+      }
+
+      let writeable = Object.values(relays)
+        .filter(({ policy }) => policy.write)
+        .sort(() => Math.random() - 0.5) // random
+
+      let maxTargets = poolPolicy.randomChoice ? poolPolicy.randomChoice : writeable.length
+
+      let successes = 0
+
+      if (poolPolicy.wait) {
+        for (let i = 0; i < writeable.length; i++) {
+          let { relay } = writeable[i]
+
+          try {
+            await new Promise(async (resolve, reject) => {
+              try {
+                await relay.publish(event, (status) => {
+                  if (statusCallback) statusCallback(status, relay.url)
+                  resolve()
+                })
+              } catch (err) {
+                if (statusCallback) statusCallback(-1, relay.url)
+              }
+            })
+
+            successes++
+            if (successes >= maxTargets) {
+              break
+            }
+          } catch (err) {
+            /***/
+          }
+        }
+      } else {
+        writeable.forEach(async ({ relay }) => {
+          let callback = statusCallback ? (status) => statusCallback(status, relay.url) : null
+          relay.publish(event, callback)
+        })
+      }
+
+      return event
+    },
+  }
+}

--- a/apps/nostr-demo/nostr-tools/relay.js
+++ b/apps/nostr-demo/nostr-tools/relay.js
@@ -1,0 +1,184 @@
+/* global WebSocket */
+
+import 'websocket-polyfill'
+
+import { verifySignature, validateEvent } from './event.js'
+import { matchFilters } from './filter.js'
+
+export function normalizeRelayURL(url) {
+  let [host, ...qs] = url.trim().split('?')
+  if (host.slice(0, 4) === 'http') host = 'ws' + host.slice(4)
+  if (host.slice(0, 2) !== 'ws') host = 'wss://' + host
+  if (host.length && host[host.length - 1] === '/') host = host.slice(0, -1)
+  return [host, ...qs].join('?')
+}
+
+export function relayConnect(url, onNotice = () => {}, onError = () => {}) {
+  url = normalizeRelayURL(url)
+
+  var ws, resolveOpen, untilOpen, wasClosed
+  var openSubs = {}
+  let attemptNumber = 1
+  let nextAttemptSeconds = 1
+
+  function resetOpenState() {
+    untilOpen = new Promise((resolve) => {
+      resolveOpen = resolve
+    })
+  }
+
+  var channels = {}
+
+  function connect() {
+    ws = new WebSocket(url)
+
+    ws.onopen = () => {
+      console.log('connected to', url)
+      resolveOpen()
+
+      // restablish old subscriptions
+      if (wasClosed) {
+        wasClosed = false
+        for (let channel in openSubs) {
+          let filters = openSubs[channel]
+          let cb = channels[channel]
+          sub({ cb, filter: filters }, channel)
+        }
+      }
+    }
+    ws.onerror = (err) => {
+      console.log('error connecting to relay', url)
+      onError(err)
+    }
+    ws.onclose = () => {
+      resetOpenState()
+      attemptNumber++
+      nextAttemptSeconds += attemptNumber ** 3
+      if (nextAttemptSeconds > 14400) {
+        nextAttemptSeconds = 14400 // 4 hours
+      }
+      console.log(`relay ${url} connection closed. reconnecting in ${nextAttemptSeconds} seconds.`)
+      setTimeout(async () => {
+        try {
+          connect()
+        } catch (err) {}
+      }, nextAttemptSeconds * 1000)
+
+      wasClosed = true
+    }
+
+    ws.onmessage = async (e) => {
+      var data
+      try {
+        data = JSON.parse(e.data)
+      } catch (err) {
+        data = e.data
+      }
+
+      if (data.length > 1) {
+        if (data[0] === 'NOTICE') {
+          if (data.length < 2) return
+
+          console.log('message from relay ' + url + ': ' + data[1])
+          onNotice(data[1])
+          return
+        }
+
+        if (data[0] === 'EVENT') {
+          if (data.length < 3) return
+
+          let channel = data[1]
+          let event = data[2]
+
+          if (
+            validateEvent(event) &&
+            verifySignature(event) &&
+            channels[channel] &&
+            matchFilters(openSubs[channel], event)
+          ) {
+            channels[channel](event)
+          }
+          return
+        }
+      }
+    }
+  }
+
+  resetOpenState()
+
+  try {
+    connect()
+  } catch (err) {}
+
+  async function trySend(params) {
+    let msg = JSON.stringify(params)
+
+    await untilOpen
+    ws.send(msg)
+  }
+
+  const sub = ({ cb, filter, beforeSend }, channel = Math.random().toString().slice(2)) => {
+    var filters = []
+    if (Array.isArray(filter)) {
+      filters = filter
+    } else {
+      filters.push(filter)
+    }
+
+    if (beforeSend) {
+      const beforeSendResult = beforeSend({ filter, relay: url, channel })
+      filters = beforeSendResult.filter
+    }
+
+    trySend(['REQ', channel, ...filters])
+    channels[channel] = cb
+    openSubs[channel] = filters
+
+    const activeCallback = cb
+    const activeFilters = filters
+    const activeBeforeSend = beforeSend
+
+    return {
+      sub: ({ cb = activeCallback, filter = activeFilters, beforeSend = activeBeforeSend }) =>
+        sub({ cb, filter, beforeSend }, channel),
+      unsub: () => {
+        delete openSubs[channel]
+        delete channels[channel]
+        trySend(['CLOSE', channel])
+      },
+    }
+  }
+
+  return {
+    url,
+    sub,
+    async publish(event, statusCallback) {
+      try {
+        await trySend(['EVENT', event])
+        if (statusCallback) {
+          statusCallback(0)
+          let { unsub } = sub(
+            {
+              cb: () => {
+                statusCallback(1)
+                unsub()
+                clearTimeout(willUnsub)
+              },
+              filter: { ids: [event.id] },
+            },
+            `monitor-${event.id.slice(0, 5)}`
+          )
+          let willUnsub = setTimeout(unsub, 5000)
+        }
+      } catch (err) {
+        if (statusCallback) statusCallback(-1)
+      }
+    },
+    close() {
+      ws.close()
+    },
+    get status() {
+      return ws.readyState
+    },
+  }
+}

--- a/apps/nostr-demo/nostr.ts
+++ b/apps/nostr-demo/nostr.ts
@@ -1,36 +1,33 @@
-import { getPublicKey, relayPool } from 'nostr-tools'
-// @ts-ignore
-import { generateSeedWords, privateKeyFromSeed, seedFromWords } from 'nostr-tools/nip06'
+import {
+  generateSeedWords, getPublicKey, privateKeyFromSeed, relayPool, seedFromWords
+} from './nostr-tools'
+
+let pubkey: string
 
 export const pool = relayPool()
-
-let pubkey: Uint8Array
 
 export const createNewAccount = () => {
   const mnemonic = generateSeedWords()
   const seed = seedFromWords(mnemonic)
   const priv = privateKeyFromSeed(seed)
-  pubkey = getPublicKey(priv)
+  pubkey = getPublicKey(Buffer.from(priv, 'hex'))
+  console.log({ mnemonic, seed, priv, pubkey })
   pool.setPrivateKey(priv)
   console.log(`Authed as ${pubkey}`)
-  pool.setPolicy('randomChoice', 3)
-  pool.addRelay('wss://relayer.fiatjaf.com')
-  pool.addRelay('wss://nostr-pub.wellorder.net')
-  pool.addRelay('wss://freedom-relay.herokuapp.com/ws')
+  pool.addRelay('wss://relay.damus.io')
 }
 
 export const subscribeToUser = async (pubkey: string) => {
   const onEvent = (event: any, relay: any) => {
     console.log(`Received event ${event.id ?? ''}`) // event, relay
   }
-
   pool.sub({
     cb: onEvent,
     filter: {
       author: pubkey,
     },
+    beforeSend: () => {},
   })
-
   console.log(`Subscribed to: ${pubkey}`)
   return true
 }

--- a/apps/nostr-demo/nostr.ts
+++ b/apps/nostr-demo/nostr.ts
@@ -1,0 +1,36 @@
+import { getPublicKey, relayPool } from 'nostr-tools'
+// @ts-ignore
+import { generateSeedWords, privateKeyFromSeed, seedFromWords } from 'nostr-tools/nip06'
+
+export const pool = relayPool()
+
+let pubkey: Uint8Array
+
+export const createNewAccount = () => {
+  const mnemonic = generateSeedWords()
+  const seed = seedFromWords(mnemonic)
+  const priv = privateKeyFromSeed(seed)
+  pubkey = getPublicKey(priv)
+  pool.setPrivateKey(priv)
+  console.log(`Authed as ${pubkey}`)
+  pool.setPolicy('randomChoice', 3)
+  pool.addRelay('wss://relayer.fiatjaf.com')
+  pool.addRelay('wss://nostr-pub.wellorder.net')
+  pool.addRelay('wss://freedom-relay.herokuapp.com/ws')
+}
+
+export const subscribeToUser = async (pubkey: string) => {
+  const onEvent = (event: any, relay: any) => {
+    console.log(`Received event ${event.id ?? ''}`) // event, relay
+  }
+
+  pool.sub({
+    cb: onEvent,
+    filter: {
+      author: pubkey,
+    },
+  })
+
+  console.log(`Subscribed to: ${pubkey}`)
+  return true
+}

--- a/apps/nostr-demo/nostr.ts
+++ b/apps/nostr-demo/nostr.ts
@@ -19,7 +19,8 @@ export const createNewAccount = () => {
 
 export const subscribeToRides = () => {
   const onEvent = (event: any, relay: any) => {
-    console.log(`Received EVENT 60 ${event.id ?? ''}`) // event, relay
+    // console.log(`Received EVENT 60 ${event.id ?? ''}`)
+    console.log(event.content)
   }
   // @ts-ignore
   pool.sub({
@@ -28,12 +29,11 @@ export const subscribeToRides = () => {
       kinds: [60],
     },
   })
-  console.log('subscribed?')
 }
 
 export const subscribeToUser = async (pubkey: string) => {
   const onEvent = (event: any, relay: any) => {
-    console.log(`Received event ${event.id ?? ''}`, event) // event, relay
+    console.log(`Received event ${event.id ?? ''}`) // event, relay
   }
   pool.sub({
     cb: onEvent,

--- a/apps/nostr-demo/nostr.ts
+++ b/apps/nostr-demo/nostr.ts
@@ -17,9 +17,23 @@ export const createNewAccount = () => {
   pool.addRelay('wss://relay.damus.io')
 }
 
+export const subscribeToRides = () => {
+  const onEvent = (event: any, relay: any) => {
+    console.log(`Received EVENT 60 ${event.id ?? ''}`) // event, relay
+  }
+  // @ts-ignore
+  pool.sub({
+    cb: onEvent,
+    filter: {
+      kinds: [60],
+    },
+  })
+  console.log('subscribed?')
+}
+
 export const subscribeToUser = async (pubkey: string) => {
   const onEvent = (event: any, relay: any) => {
-    console.log(`Received event ${event.id ?? ''}`) // event, relay
+    console.log(`Received event ${event.id ?? ''}`, event) // event, relay
   }
   pool.sub({
     cb: onEvent,

--- a/apps/nostr-demo/package.json
+++ b/apps/nostr-demo/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@arcadecity/ui": "*",
     "@expo/webpack-config": "^0.16.23",
+    "@noble/secp256k1": "1.6.3",
     "@scure/bip32": "^1.1.0",
     "@scure/bip39": "^1.1.0",
     "expo": "~46.0.0-beta.6",
@@ -20,7 +21,9 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.1",
     "react-native-web": "~0.18.7",
-    "text-encoding-polyfill": "^0.6.7"
+    "text-encoding-polyfill": "^0.6.7",
+    "tiny-secp256k1": "^2.2.1",
+    "websocket-polyfill": "^0.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/apps/nostr-demo/package.json
+++ b/apps/nostr-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nostr-demo",
+  "name": "@arcadecity/nostr-demo",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -11,12 +11,16 @@
   "dependencies": {
     "@arcadecity/ui": "*",
     "@expo/webpack-config": "^0.16.23",
+    "@scure/bip32": "^1.1.0",
+    "@scure/bip39": "^1.1.0",
     "expo": "~46.0.0-beta.6",
+    "expo-random": "~12.3.0",
     "expo-status-bar": "~1.4.0",
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-native": "0.69.1",
-    "react-native-web": "~0.18.7"
+    "react-native-web": "~0.18.7",
+    "text-encoding-polyfill": "^0.6.7"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "apps/*",
     "packages/*"
   ],
+  "scripts": {
+    "start": "yarn workspace @arcadecity/nostr-demo start",
+    "postinstall": "npx patch-package"
+  },
   "prettier": {
     "arrowParens": "always",
     "bracketSameLine": true,

--- a/patches/@noble+hashes+1.1.2.patch
+++ b/patches/@noble+hashes+1.1.2.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/@noble/hashes/utils.js b/node_modules/@noble/hashes/utils.js
+index 02520d0..88c4beb 100644
+--- a/node_modules/@noble/hashes/utils.js
++++ b/node_modules/@noble/hashes/utils.js
+@@ -155,7 +155,12 @@ function randomBytes(bytesLength = 32) {
+         return new Uint8Array(crypto_1.crypto.node.randomBytes(bytesLength).buffer);
+     }
+     else {
+-        throw new Error("The environment doesn't have randomBytes function");
++        try {
++            const randomBytes = require('expo-random').getRandomBytes;
++            return randomBytes(bytesLength);
++        } catch (e) {
++            throw new Error("The environment doesn't have randomBytes function and we couldn't use expo-random");
++        }
+     }
+ }
+ exports.randomBytes = randomBytes;

--- a/patches/metro-react-native-babel-preset+0.70.3.patch
+++ b/patches/metro-react-native-babel-preset+0.70.3.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/metro-react-native-babel-preset/src/configs/main.js b/node_modules/metro-react-native-babel-preset/src/configs/main.js
+index 8c05035..ebcc3f8 100644
+--- a/node_modules/metro-react-native-babel-preset/src/configs/main.js
++++ b/node_modules/metro-react-native-babel-preset/src/configs/main.js
+@@ -135,11 +135,11 @@ const getPreset = (src, options) => {
+     extraPlugins.push([require("@babel/plugin-transform-async-to-generator")]);
+   }
+ 
+-  if (!isHermes && (isNull || src.indexOf("**") !== -1)) {
+-    extraPlugins.push([
+-      require("@babel/plugin-transform-exponentiation-operator"),
+-    ]);
+-  }
++  // if (!isHermes && (isNull || src.indexOf("**") !== -1)) {
++  //   extraPlugins.push([
++  //     require("@babel/plugin-transform-exponentiation-operator"),
++  //   ]);
++  // }
+ 
+   if (
+     isNull ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,6 +1559,16 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@noble/hashes@~1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
+  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+
+"@noble/secp256k1@~1.6.0":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.3.tgz#7eed12d9f4404b416999d0c87686836c4c5c9b94"
+  integrity sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1779,6 +1789,28 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
+
+"@scure/base@~1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
+
+"@scure/bip32@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.1.0.tgz#dea45875e7fbc720c2b4560325f1cf5d2246d95b"
+  integrity sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==
+  dependencies:
+    "@noble/hashes" "~1.1.1"
+    "@noble/secp256k1" "~1.6.0"
+    "@scure/base" "~1.1.0"
+
+"@scure/bip39@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.1.0.tgz#92f11d095bae025f166bef3defcc5bf4945d419a"
+  integrity sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==
+  dependencies:
+    "@noble/hashes" "~1.1.1"
+    "@scure/base" "~1.1.0"
 
 "@segment/loosely-validate-event@^2.0.0":
   version "2.0.0"
@@ -2570,7 +2602,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.2.3, base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.2.3, base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -4439,6 +4471,13 @@ expo-pwa@0.0.121:
     chalk "^4.0.0"
     commander "2.20.0"
     update-check "1.5.3"
+
+expo-random@~12.3.0:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/expo-random/-/expo-random-12.3.0.tgz#4a45bcb14e285a4a9161e4a5dc82ff6c3fc2ac0c"
+  integrity sha512-q+AsTfGNT+Q+fb2sRrYtRkI3g5tV4H0kuYXM186aueILGO/vLn/YYFa7xFZj1IZ8LJZg2h96JDPDpsqHfRG2mQ==
+  dependencies:
+    base64-js "^1.3.0"
 
 expo-status-bar@~1.4.0:
   version "1.4.0"
@@ -9618,6 +9657,11 @@ terser@^4.1.2, terser@^4.6.3, terser@^4.8.0:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
+
+text-encoding-polyfill@^0.6.7:
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz#4d27de0153e4c86eb2631ffd74c2f3f57969a9ec"
+  integrity sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg==
 
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,7 +1564,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
   integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
 
-"@noble/secp256k1@~1.6.0":
+"@noble/secp256k1@1.6.3", "@noble/secp256k1@~1.6.0":
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.3.tgz#7eed12d9f4404b416999d0c87686836c4c5c9b94"
   integrity sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==
@@ -2934,6 +2934,13 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+bufferutil@^4.0.1:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.6.tgz#ebd6c67c7922a0e902f053e5d8be5ec850e48433"
+  integrity sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -3799,6 +3806,14 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
 
+d@1, d@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
+  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
+  dependencies:
+    es5-ext "^0.10.50"
+    type "^1.0.1"
+
 dag-map@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-1.0.2.tgz#e8379f041000ed561fc515475c1ed2c85eece8d7"
@@ -4272,6 +4287,32 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es5-ext@^0.10.35, es5-ext@^0.10.50:
+  version "0.10.61"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.61.tgz#311de37949ef86b6b0dcea894d1ffedb909d3269"
+  integrity sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==
+  dependencies:
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.3"
+    next-tick "^1.1.0"
+
+es6-iterator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
+  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
+  dependencies:
+    d "^1.0.1"
+    ext "^1.1.2"
+
 escalade@^3.0.2, escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -4548,6 +4589,13 @@ express@^4.17.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+ext@^1.1.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.6.0.tgz#3871d50641e874cc172e2b53f919842d19db4c52"
+  integrity sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==
+  dependencies:
+    type "^2.5.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -5924,6 +5972,11 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
@@ -7085,6 +7138,11 @@ nested-error-stacks@~2.0.1:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz#d2cc9fc5235ddb371fc44d506234339c8e4b0a4b"
   integrity sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==
 
+next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -7126,6 +7184,11 @@ node-forge@^1.2.1, node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
+node-gyp-build@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
+  integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
 
 node-html-parser@^1.2.12:
   version "1.4.9"
@@ -9717,6 +9780,13 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==
 
+tiny-secp256k1@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz#a61d4791b7031aa08a9453178a131349c3e10f9b"
+  integrity sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==
+  dependencies:
+    uint8array-tools "0.0.7"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9811,6 +9881,11 @@ tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tstl@^2.0.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/tstl/-/tstl-2.5.7.tgz#c3d2f6b87c5529156a68ca2ec3295c6511d74625"
+  integrity sha512-h0D6dJGsE7oa1hqsO0xpUfU+B19QZMzfeIqiepCbq4etydEV4Jk2FJ3o+jJaahwOTW5JcRZzZjBkF1jRXgwq1A==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -9849,6 +9924,23 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+type@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
+  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+
+type@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f"
+  integrity sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -9871,6 +9963,11 @@ uglify-es@^3.1.9:
   dependencies:
     commander "~2.13.0"
     source-map "~0.6.1"
+
+uint8array-tools@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/uint8array-tools/-/uint8array-tools-0.0.7.tgz#a7a2bb5d8836eae2fade68c771454e6a438b390d"
+  integrity sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -10058,6 +10155,13 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf-8-validate@^5.0.2:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.9.tgz#ba16a822fbeedff1a58918f2a6a6b36387493ea3"
+  integrity sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==
+  dependencies:
+    node-gyp-build "^4.3.0"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -10323,6 +10427,26 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
+websocket-polyfill@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/websocket-polyfill/-/websocket-polyfill-0.0.3.tgz#7321ada0f5f17516290ba1cb587ac111b74ce6a5"
+  integrity sha512-pF3kR8Uaoau78MpUmFfzbIRxXj9PeQrCuPepGE6JIsfsJ/o/iXr07Q2iQNzKSSblQJ0FiGWlS64N4pVSm+O3Dg==
+  dependencies:
+    tstl "^2.0.7"
+    websocket "^1.0.28"
+
+websocket@^1.0.28:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
+  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
+  dependencies:
+    bufferutil "^4.0.1"
+    debug "^2.2.0"
+    es5-ext "^0.10.50"
+    typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
+    yaeti "^0.0.6"
+
 whatwg-fetch@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
@@ -10478,6 +10602,11 @@ y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+  integrity sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
Pulling recent ride requests (Nostr event type 60) from the relay used in the [Bullrun demo](https://github.com/ArcadeCity/bullrun). 

For now this works only on web, until we shim or replace @noble/secp256k1 (used by [nostr-tools](https://github.com/fiatjaf/nostr-tools)) because the noble lib [does not work as-is with React Native](https://github.com/paulmillr/noble-secp256k1/issues/31).

Next will build a UI to format requests nicely and allow responding from our client.

![nostr-ride-requests](https://user-images.githubusercontent.com/14167547/180109189-8c605e04-44eb-4da9-a4ec-fe8eece48845.png)

